### PR TITLE
Frontend and Renovate fixes for 2026 scan

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
     <title>Pin GitHub Actions</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/themes/prism.css" rel="stylesheet" />
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -24,12 +24,12 @@
 
 <body class="flex flex-col items-center py-6 bg-gray-100 min-h-screen">
     <!-- Title  -->
-    <header class="w-full bg-white shadow py-4 mb-6">
+    <header class="w-full bg-white shadow-sm py-4 mb-6">
         <h1 class="text-2xl font-bold text-center">Pin GitHub Actions</h1>
     </header>
 
     <!-- Chart & Result  -->
-    <div class="flex flex-col md:flex-row items-center justify-center max-w-4xl bg-white shadow p-12 rounded-lg">
+    <div class="flex flex-col md:flex-row items-center justify-center max-w-4xl bg-white shadow-sm p-12 rounded-lg">
         <div class="w-full max-w-sm">
             <!-- Year Toggle -->
             <div class="mb-4 text-center">
@@ -68,7 +68,7 @@
     </div>
 
     <!-- Motivation -->
-    <div class="mt-6 w-full max-w-4xl bg-white shadow p-12 rounded-lg text-justify">
+    <div class="mt-6 w-full max-w-4xl bg-white shadow-sm p-12 rounded-lg text-justify">
         <h2 class="text-2xl font-bold text-center mb-4">Why you should pin your GitHub Actions?</h2>
         <p class="mt-2 text-base">Most GitHub Action pipelines are composed of 3rd party Actions. To use one, point to a git repository that hosts this Action and reference a version, such as a branch (<code class="language-yaml">@main</code>) or a tag (<code class="language-yaml">@v1</code>).</p>
         <div class="relative my-4 w-full max-w-3xl mx-auto">
@@ -104,7 +104,7 @@
     </div>
 
     <!-- How to pin GH Actions-->
-    <div class="mt-6 w-full max-w-4xl bg-white shadow p-12 rounded-lg text-justify">
+    <div class="mt-6 w-full max-w-4xl bg-white shadow-sm p-12 rounded-lg text-justify">
         <h2 class="text-2xl font-bold text-center">How to secure (and update) your GitHub Actions?</h2>
 
         <p class="mt-2 text-base">Neither managing hashes nor manually updating Actions is fun or developer-friendly. We take the pain out of this process with tools and automations available to the community.</p>
@@ -144,7 +144,7 @@
     </div>
 
     <!-- Limitations -->
-    <div class="mt-6 w-full max-w-4xl bg-white shadow p-8 rounded-lg text-justify">
+    <div class="mt-6 w-full max-w-4xl bg-white shadow-sm p-8 rounded-lg text-justify">
         <h2 class="text-2xl font-bold text-center">Known Limitations</h2>
 
         <p class="mt-2 text-base">Pinning GitHub Actions will not protect us from all attacks. It is important to understand which risks remain.</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/themes/prism.css" rel="stylesheet" />
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/prism.js"></script>
     <script src="pinned-actions-chart.js"></script>
 

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,23 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^frontend/index\\.html$"],
+      "matchStrings": [
+        "cdn\\.jsdelivr\\.net/npm/(?<depName>@?[^@/]+(?:/[^@/]+)?)@(?<currentValue>[^/\"'\\s]+)"
+      ],
+      "datasourceTemplate": "npm"
+    },
+    {
+      "fileMatch": ["^frontend/index\\.html$"],
+      "matchStrings": [
+        "cdnjs\\.cloudflare\\.com/ajax/libs/(?<depName>[^/]+)/(?<currentValue>[^/]+)/"
+      ],
+      "datasourceTemplate": "cdnjs"
+    }
+  ],
+
   "packageRules": [
     {
       "groupName": "Go",

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,8 @@
   "commitMessagePrefix": "fix(deps): ",
   "addLabels": ["dependencies"],
 
+  "ignorePaths": ["testdata/**"],
+
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"


### PR DESCRIPTION
## Summary

- Exclude `testdata/**` from Renovate — pinned hashes there are test fixtures, not real dependencies
- Migrate Tailwind CSS v2 → v4 via `@tailwindcss/browser` CDN; fix one breaking class change (`shadow` → `shadow-sm`)
- Pin Chart.js to `4.5.1` on jsDelivr; add Renovate `regexManagers` to track all CDN dependencies in `frontend/index.html` (Chart.js, `@tailwindcss/browser` via npm datasource, Prism via cdnjs datasource)

No Dependabot alerts remain — all 16 findings were cleared by the previous PR's dependency updates.

## Test plan

- [x] Cloudflare deployment verified visually — no layout difference from v2
- [ ] CI passes
- [ ] Renovate picks up CDN dependencies correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)