### PR TITLE
Fix search pagination stopping prematurely

### DIFF
--- a/repo_downloader.go
+++ b/repo_downloader.go
@@ -45,7 +45,7 @@ func (r *RepositoryDownloader) Download(ctx context.Context, downloaded chan str
 	for i := 0; i < r.config.MaxPages; i++ {
 		query := buildQuery(minStars, maxStars)
 		log.Printf("Searching repos with: %s\n", query)
-		searchResult, resp, err := r.client.Search.Repositories(ctx, query, opts)
+		searchResult, _, err := r.client.Search.Repositories(ctx, query, opts)
 		if err != nil {
 			return fmt.Errorf("searching repositories: %w", err)
 		}
@@ -53,6 +53,8 @@ func (r *RepositoryDownloader) Download(ctx context.Context, downloaded chan str
 		if searchResult == nil {
 			return fmt.Errorf("no search results")
 		}
+
+		log.Printf("Found %d repositories\n", len(searchResult.Repositories))
 
 		for _, repository := range searchResult.Repositories {
 			maxStars = repository.GetStargazersCount() - 1
@@ -63,7 +65,7 @@ func (r *RepositoryDownloader) Download(ctx context.Context, downloaded chan str
 			downloaded <- repository.GetFullName()
 		}
 
-		if resp.NextPage == 0 {
+		if len(searchResult.Repositories) < r.config.PerPage {
 			log.Printf("Handled all pages after %d requests.\n", i+1)
 			break
 		}


### PR DESCRIPTION
## Summary

- Replace `resp.NextPage == 0` termination check with `len(searchResult.Repositories) < r.config.PerPage`
- Add per-request result count logging to aid future debugging

## Root cause

go-github v85 populates `resp.Cursor` instead of `resp.NextPage` when the GitHub Search API returns cursor-based `Link` headers. This leaves `NextPage` at 0 even when more results exist, causing the scanner to exit after the first search request instead of continuing through all 100 pages.

The new condition is semantically unambiguous: stop only when the API returns fewer repositories than requested, which means the current star range is genuinely exhausted.

## Test plan

- [ ] CI passes
- [ ] Run scanner against a small set (e.g. `-max-pages 3`) and confirm it processes 3 × 100 repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)