### PR TITLE
Fix unauthenticated search returning 0 results

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,11 @@ func main() {
 	config := ParseArgs()
 	log.Printf("Configuration:\n%s", config)
 
-	client := github.NewClient(nil)
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		log.Printf("[WARN] GITHUB_TOKEN not set; unauthenticated search requests are heavily rate-limited and may return incomplete results")
+	}
+	client := github.NewClient(nil).WithAuthToken(token)
 
 	ctx := context.Background()
 

--- a/repo_downloader.go
+++ b/repo_downloader.go
@@ -54,6 +54,12 @@ func (r *RepositoryDownloader) Download(ctx context.Context, downloaded chan str
 			return fmt.Errorf("no search results")
 		}
 
+		if searchResult.GetIncompleteResults() {
+			log.Printf("[WARN] GitHub returned incomplete results for query %q — retrying\n", query)
+			i--
+			continue
+		}
+
 		log.Printf("Found %d repositories\n", len(searchResult.Repositories))
 
 		for _, repository := range searchResult.Repositories {


### PR DESCRIPTION
## Summary

- Add `GITHUB_TOKEN` environment variable support — authenticated requests get 30 search req/min (vs 10) and higher server-side priority, preventing GitHub from timing out on broad queries like `stars:1000..500000`
- Retry automatically when GitHub returns `incomplete_results=true` (server-side query timeout) instead of silently processing 0 repositories and terminating

## Usage

```sh
export GITHUB_TOKEN=<your-token>
./pinned-actions -download-dir /data/... -max-pages 100
```

A read-only public token (no special scopes) is sufficient. A warning is printed if the token is not set.

## Test plan

- [ ] CI passes
- [ ] Run with `GITHUB_TOKEN` set and confirm "Found 100 repositories" appears on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)