### PR TITLE
feat: add Zizmor GitHub Actions security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Zizmor
 
 on:
   push:
@@ -11,11 +11,12 @@ on:
 permissions: {}
 
 jobs:
-  build:
-    name: Build
+  zizmor:
+    name: Zizmor
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      security-events: write # for uploading SARIF results to GitHub Code Scanning
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -24,13 +25,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-    - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: go.mod
-    - name: Build
-      run: go build ./...
-    - name: Test
-      run: go test ./...
-    - name: Lint
-      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+    - name: Run Zizmor
+      uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/zizmor.yml` — runs [zizmor](https://github.com/woodruffw/zizmor) on every push/PR to catch GitHub Actions security issues early; results are uploaded as SARIF to GitHub Code Scanning
- Fixes `concurrency-limits` finding (zizmor pedantic): both CI and Zizmor jobs now have a concurrency group that cancels in-progress runs on the same ref (except on `main`)

## zizmor findings resolved

Before: 0 regular findings, 1 pedantic (`concurrency-limits`)
After: 0 findings in pedantic mode

## Test plan

- [ ] Zizmor workflow runs and passes on this PR
- [ ] SARIF results appear in the Security → Code Scanning tab
- [ ] CI job concurrency group does not break normal builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)