### PR TITLE
feat: multi-analyzer architecture

### DIFF
--- a/analysis_immutable.go
+++ b/analysis_immutable.go
@@ -52,7 +52,7 @@ func (im *ImmutableReleasesAnalyzer) Analyze(ctx context.Context, _, repo string
 		}
 		return fmt.Errorf("fetching latest release for %s: %w", repo, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	im.results = append(im.results, ImmutableResult{
 		Repository:             repo,
@@ -67,9 +67,9 @@ func (im *ImmutableReleasesAnalyzer) Close() error {
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", out, err)
 	}
-	defer f.Close()
 	if err := json.NewEncoder(f).Encode(im.results); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("encoding %s: %w", out, err)
 	}
-	return nil
+	return f.Close()
 }

--- a/analysis_immutable.go
+++ b/analysis_immutable.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-github/v85/github"
+)
+
+// ImmutableResult records whether the latest release of a repository is
+// marked as immutable using GitHub's Immutable Releases feature.
+type ImmutableResult struct {
+	Repository             string `json:"repository"`
+	LatestReleaseImmutable bool   `json:"latest_release_immutable"`
+}
+
+// ImmutableReleasesAnalyzer checks whether the latest GitHub release for each
+// repository is marked immutable. It requires a GitHub API token for
+// reasonable rate limits (one API call per repository).
+type ImmutableReleasesAnalyzer struct {
+	client    *github.Client
+	resultDir string
+	results   []ImmutableResult
+}
+
+func NewImmutableReleasesAnalyzer(client *github.Client, resultDir string) *ImmutableReleasesAnalyzer {
+	return &ImmutableReleasesAnalyzer{client: client, resultDir: resultDir}
+}
+
+func (im *ImmutableReleasesAnalyzer) Name() string { return "immutable" }
+
+func (im *ImmutableReleasesAnalyzer) Analyze(ctx context.Context, _, repo string) error {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("unexpected repo format %q (want owner/name)", repo)
+	}
+	owner, name := parts[0], parts[1]
+
+	release, resp, err := im.client.Repositories.GetLatestRelease(ctx, owner, name)
+	if err != nil {
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			// No releases published — not using immutable releases.
+			im.results = append(im.results, ImmutableResult{Repository: repo})
+			return nil
+		}
+		return fmt.Errorf("fetching latest release for %s: %w", repo, err)
+	}
+	defer resp.Body.Close()
+
+	im.results = append(im.results, ImmutableResult{
+		Repository:             repo,
+		LatestReleaseImmutable: release.GetImmutable(),
+	})
+	return nil
+}
+
+func (im *ImmutableReleasesAnalyzer) Close() error {
+	out := filepath.Join(im.resultDir, "immutable.json")
+	f, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", out, err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(im.results); err != nil {
+		return fmt.Errorf("encoding %s: %w", out, err)
+	}
+	return nil
+}

--- a/analysis_pinned.go
+++ b/analysis_pinned.go
@@ -50,11 +50,11 @@ func (p *PinnedAnalyzer) Close() error {
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", out, err)
 	}
-	defer f.Close()
 	if err := json.NewEncoder(f).Encode(p.results); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("encoding %s: %w", out, err)
 	}
-	return nil
+	return f.Close()
 }
 
 func analyseRepository(dir string, repo string) (Analysis, error) {

--- a/analysis_pinned.go
+++ b/analysis_pinned.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -19,43 +22,47 @@ type Analysis struct {
 	HasDependabot bool   `json:"has_dependabot"`
 }
 
-func NewAnalysis(repository string) Analysis {
-	return Analysis{
-		Repository:    repository,
-		ActionsPinned: 0,
-		ActionsTotal:  0,
-		HasRenovate:   false,
-		HasDependabot: false,
+// PinnedAnalyzer checks what fraction of GitHub Actions in each repository
+// are pinned to a full-length commit SHA or OCI digest.
+type PinnedAnalyzer struct {
+	resultDir string
+	results   []Analysis
+}
+
+func NewPinnedAnalyzer(resultDir string) *PinnedAnalyzer {
+	return &PinnedAnalyzer{resultDir: resultDir}
+}
+
+func (p *PinnedAnalyzer) Name() string { return "pinned" }
+
+func (p *PinnedAnalyzer) Analyze(_ context.Context, repoPath, repo string) error {
+	analysis, err := analyseRepository(repoPath, repo)
+	if err != nil {
+		return err
 	}
+	p.results = append(p.results, analysis)
+	return nil
 }
 
-func (a *Analysis) CountPinned() {
-	a.ActionsPinned++
-	a.ActionsTotal++
-}
-
-func (a *Analysis) CountUnpinned() {
-	a.ActionsTotal++
-}
-
-func (a Analysis) String() string {
-	updater := "None"
-	if a.HasRenovate {
-		updater = "Renovate"
+func (p *PinnedAnalyzer) Close() error {
+	out := filepath.Join(p.resultDir, "pinned.json")
+	f, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", out, err)
 	}
-	if a.HasDependabot {
-		updater = "Dependabot"
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(p.results); err != nil {
+		return fmt.Errorf("encoding %s: %w", out, err)
 	}
-	return fmt.Sprintf("%s: %d/%d (%s)", a.Repository, a.ActionsPinned, a.ActionsTotal, updater)
+	return nil
 }
 
-func AnalyseRepository(dir string, repo string) (Analysis, error) {
-	analysis := NewAnalysis(repo)
+func analyseRepository(dir string, repo string) (Analysis, error) {
+	analysis := Analysis{Repository: repo}
 
 	repoPath := filepath.Join(dir, repo)
 	workflowsPath := filepath.Join(repoPath, ".github", "workflows")
 
-	// Create a new Frizbee instance
 	r := replacer.NewGitHubActionsReplacer(&fzconfig.Config{})
 
 	actions, err := r.ListPath(workflowsPath)
@@ -67,15 +74,17 @@ func AnalyseRepository(dir string, repo string) (Analysis, error) {
 		switch action.Type {
 		case "container":
 			if len(action.Ref) == 71 && strings.HasPrefix(action.Ref, "sha256:") {
-				analysis.CountPinned()
+				analysis.ActionsPinned++
+				analysis.ActionsTotal++
 			} else {
-				analysis.CountUnpinned()
+				analysis.ActionsTotal++
 			}
 		case "action":
 			if len(action.Ref) == 40 && isHex(action.Ref) {
-				analysis.CountPinned()
+				analysis.ActionsPinned++
+				analysis.ActionsTotal++
 			} else {
-				analysis.CountUnpinned()
+				analysis.ActionsTotal++
 			}
 		default:
 			log.Printf("[WARN] unknown action type: %s", action.Type)
@@ -94,11 +103,9 @@ func AnalyseRepository(dir string, repo string) (Analysis, error) {
 		filepath.Join(repoPath, ".renovaterc.json"),
 		filepath.Join(repoPath, ".renovaterc.json5"),
 	}
-
-	renovate := slices.ContainsFunc(renovatePaths, func(path string) bool {
+	analysis.HasRenovate = slices.ContainsFunc(renovatePaths, func(path string) bool {
 		return exists(path)
 	})
-	analysis.HasRenovate = renovate
 
 	dependabotPath := filepath.Join(repoPath, ".github", "dependabot.yml")
 	if exists(dependabotPath) {

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +30,7 @@ func TestIsHex(t *testing.T) {
 	}
 }
 
-func TestAnalyseRepository(t *testing.T) {
+func TestPinnedAnalyzer(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
@@ -77,13 +78,16 @@ func TestAnalyseRepository(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			analysis, err := AnalyseRepository(testdata, test.repo)
+			a := NewPinnedAnalyzer(t.TempDir())
+			err := a.Analyze(context.Background(), testdata, test.repo)
 			assert.NoError(t, err)
 
-			assert.Equal(t, test.wantPinned, analysis.ActionsPinned)
-			assert.Equal(t, test.wantTotal, analysis.ActionsTotal)
-			assert.Equal(t, test.wantHasRenovate, analysis.HasRenovate)
-			assert.Equal(t, test.wantHasDependabot, analysis.HasDependabot)
+			require.Len(t, a.results, 1)
+			got := a.results[0]
+			assert.Equal(t, test.wantPinned, got.ActionsPinned)
+			assert.Equal(t, test.wantTotal, got.ActionsTotal)
+			assert.Equal(t, test.wantHasRenovate, got.HasRenovate)
+			assert.Equal(t, test.wantHasDependabot, got.HasDependabot)
 		})
 	}
 }

--- a/analysis_zizmor.go
+++ b/analysis_zizmor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -62,6 +63,14 @@ func (z *ZizmorAnalyzer) Analyze(_ context.Context, repoPath, repo string) error
 	cmd.Stdout = &stdout
 
 	if err := cmd.Run(); err != nil {
+		// Exit code 3 means zizmor found no auditable inputs (e.g. .github/
+		// exists but contains only issue templates, not workflows or actions).
+		// Treat this the same as an empty findings list.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 3 {
+			z.results = append(z.results, ZizmorResult{Repository: repo, Findings: []ZizmorFinding{}})
+			return nil
+		}
 		return fmt.Errorf("running zizmor: %w", err)
 	}
 

--- a/analysis_zizmor.go
+++ b/analysis_zizmor.go
@@ -83,11 +83,11 @@ func (z *ZizmorAnalyzer) Close() error {
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", out, err)
 	}
-	defer f.Close()
 	if err := json.NewEncoder(f).Encode(z.results); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("encoding %s: %w", out, err)
 	}
-	return nil
+	return f.Close()
 }
 
 // zizmorRawFinding mirrors the relevant subset of zizmor's JSON output.

--- a/analysis_zizmor.go
+++ b/analysis_zizmor.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ZizmorFinding is one security finding emitted by zizmor for a single
+// workflow file.
+type ZizmorFinding struct {
+	Rule       string `json:"rule"`
+	Severity   string `json:"severity"`
+	Confidence string `json:"confidence"`
+	File       string `json:"file"`
+	Line       int    `json:"line"`
+}
+
+// ZizmorResult collects all findings for one repository.
+type ZizmorResult struct {
+	Repository string          `json:"repository"`
+	Findings   []ZizmorFinding `json:"findings"`
+}
+
+// ZizmorAnalyzer runs zizmor against the .github/ directory of each
+// repository. It requires the zizmor binary to be present on $PATH.
+type ZizmorAnalyzer struct {
+	zizmorBin string
+	resultDir string
+	results   []ZizmorResult
+}
+
+func NewZizmorAnalyzer(resultDir string) (*ZizmorAnalyzer, error) {
+	bin, err := exec.LookPath("zizmor")
+	if err != nil {
+		return nil, fmt.Errorf("zizmor not found on $PATH: %w", err)
+	}
+	return &ZizmorAnalyzer{zizmorBin: bin, resultDir: resultDir}, nil
+}
+
+func (z *ZizmorAnalyzer) Name() string { return "zizmor" }
+
+func (z *ZizmorAnalyzer) Analyze(_ context.Context, repoPath, repo string) error {
+	githubDir := filepath.Join(repoPath, repo, ".github")
+	if !exists(githubDir) {
+		z.results = append(z.results, ZizmorResult{Repository: repo, Findings: []ZizmorFinding{}})
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	cmd := exec.Command(z.zizmorBin,
+		"--format=json",
+		"--offline",
+		"--no-exit-codes",
+		githubDir,
+	)
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running zizmor: %w", err)
+	}
+
+	findings, err := parseZizmorOutput(stdout.Bytes(), repoPath, repo)
+	if err != nil {
+		return fmt.Errorf("parsing zizmor output: %w", err)
+	}
+
+	z.results = append(z.results, ZizmorResult{
+		Repository: repo,
+		Findings:   findings,
+	})
+	return nil
+}
+
+func (z *ZizmorAnalyzer) Close() error {
+	out := filepath.Join(z.resultDir, "zizmor.json")
+	f, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", out, err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(z.results); err != nil {
+		return fmt.Errorf("encoding %s: %w", out, err)
+	}
+	return nil
+}
+
+// zizmorRawFinding mirrors the relevant subset of zizmor's JSON output.
+type zizmorRawFinding struct {
+	Ident          string `json:"ident"`
+	Determinations struct {
+		Severity   string `json:"severity"`
+		Confidence string `json:"confidence"`
+	} `json:"determinations"`
+	Locations []struct {
+		Symbolic struct {
+			Key struct {
+				Local *struct {
+					GivenPath string `json:"given_path"`
+				} `json:"Local"`
+			} `json:"key"`
+		} `json:"symbolic"`
+		Concrete struct {
+			Location struct {
+				StartPoint struct {
+					Row int `json:"row"`
+				} `json:"start_point"`
+			} `json:"location"`
+		} `json:"concrete"`
+	} `json:"locations"`
+}
+
+func parseZizmorOutput(data []byte, repoPath, repo string) ([]ZizmorFinding, error) {
+	var raw []zizmorRawFinding
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	absRepoPath := filepath.Join(repoPath, repo)
+	var findings []ZizmorFinding
+	for _, r := range raw {
+		f := ZizmorFinding{
+			Rule:       r.Ident,
+			Severity:   r.Determinations.Severity,
+			Confidence: r.Determinations.Confidence,
+		}
+		// Use the first location that has a concrete file path.
+		for _, loc := range r.Locations {
+			if loc.Symbolic.Key.Local != nil {
+				f.File = strings.TrimPrefix(loc.Symbolic.Key.Local.GivenPath, absRepoPath+"/")
+				f.Line = loc.Concrete.Location.StartPoint.Row
+				break
+			}
+		}
+		findings = append(findings, f)
+	}
+	return findings, nil
+}

--- a/analyzer.go
+++ b/analyzer.go
@@ -1,0 +1,16 @@
+package main
+
+import "context"
+
+// Analyzer is implemented by every analysis pass that runs against a
+// downloaded repository. Offline analyzers inspect the local checkout;
+// online analyzers may additionally call external APIs.
+//
+// Analyze is called once per repository. Close is called exactly once after
+// all repositories have been processed; implementations should flush any
+// accumulated results to disk there.
+type Analyzer interface {
+	Name() string
+	Analyze(ctx context.Context, repoPath, repo string) error
+	Close() error
+}

--- a/args.go
+++ b/args.go
@@ -15,7 +15,7 @@ func ParseArgs() Config {
 	fs.IntVar(&config.MaxPages, "max-pages", 1, "maximum number of pages to download")
 	fs.IntVar(&config.PerPage, "per-page", 100, "number of repositories to download per page")
 
-	analyzerFlag := fs.String("analyzer", "pinned", "comma-separated list of analyzers to run (available: pinned, zizmor)")
+	analyzerFlag := fs.String("analyzer", "pinned", "comma-separated list of analyzers to run (available: pinned, zizmor, immutable)")
 
 	err := fs.Parse(os.Args[1:])
 	if err != nil {

--- a/args.go
+++ b/args.go
@@ -10,6 +10,7 @@ func ParseArgs() Config {
 	fs := flag.NewFlagSet("GH Pinned Actions", flag.ExitOnError)
 
 	fs.StringVar(&config.DownloadDir, "download-dir", "/tmp/pinned", "path to folder where repositories will be downloaded")
+	fs.StringVar(&config.ResultDir, "result-dir", "results", "path to folder where analysis results will be written")
 	fs.IntVar(&config.MaxPages, "max-pages", 1, "maximum number of pages to download")
 	fs.IntVar(&config.PerPage, "per-page", 100, "number of repositories to download per page")
 

--- a/args.go
+++ b/args.go
@@ -15,7 +15,7 @@ func ParseArgs() Config {
 	fs.IntVar(&config.MaxPages, "max-pages", 1, "maximum number of pages to download")
 	fs.IntVar(&config.PerPage, "per-page", 100, "number of repositories to download per page")
 
-	analyzerFlag := fs.String("analyzer", "pinned", "comma-separated list of analyzers to run (available: pinned, zizmor, immutable)")
+	analyzerFlag := fs.String("analyzer", "pinned", "comma-separated list of analyzers to run (available: pinned, zizmor)")
 
 	err := fs.Parse(os.Args[1:])
 	if err != nil {

--- a/args.go
+++ b/args.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 )
 
 func ParseArgs() Config {
@@ -14,11 +15,15 @@ func ParseArgs() Config {
 	fs.IntVar(&config.MaxPages, "max-pages", 1, "maximum number of pages to download")
 	fs.IntVar(&config.PerPage, "per-page", 100, "number of repositories to download per page")
 
+	analyzerFlag := fs.String("analyzer", "pinned", "comma-separated list of analyzers to run (available: pinned, zizmor, immutable)")
+
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
 		fs.PrintDefaults()
 		os.Exit(1)
 	}
+
+	config.Analyzers = strings.Split(*analyzerFlag, ",")
 
 	return *config
 }

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	Query       string
 	DownloadDir string
 	ResultDir   string
+	Analyzers   []string
 }
 
 func NewConfig() *Config {
@@ -17,6 +18,7 @@ func NewConfig() *Config {
 		Query:       "stars:>1000",
 		DownloadDir: "/tmp/pinned",
 		ResultDir:   "results",
+		Analyzers:   []string{"pinned"},
 	}
 }
 
@@ -27,5 +29,6 @@ func (c Config) String() string {
 	s += "Query: " + c.Query + "\n"
 	s += "DownloadDir: " + c.DownloadDir + "\n"
 	s += "ResultDir: " + c.ResultDir + "\n"
+	s += "Analyzers: " + fmt.Sprint(c.Analyzers) + "\n"
 	return s
 }

--- a/config.go
+++ b/config.go
@@ -7,7 +7,6 @@ type Config struct {
 	MaxPages    int
 	Query       string
 	DownloadDir string
-	ResultFile  string
 	ResultDir   string
 }
 
@@ -17,7 +16,6 @@ func NewConfig() *Config {
 		MaxPages:    1,
 		Query:       "stars:>1000",
 		DownloadDir: "/tmp/pinned",
-		ResultFile:  "result.json",
 		ResultDir:   "results",
 	}
 }
@@ -28,6 +26,6 @@ func (c Config) String() string {
 	s += "MaxPages: " + fmt.Sprint(c.MaxPages) + "\n"
 	s += "Query: " + c.Query + "\n"
 	s += "DownloadDir: " + c.DownloadDir + "\n"
-	s += "ResultFile: " + c.ResultFile + "\n"
+	s += "ResultDir: " + c.ResultDir + "\n"
 	return s
 }

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	Query       string
 	DownloadDir string
 	ResultFile  string
+	ResultDir   string
 }
 
 func NewConfig() *Config {
@@ -17,6 +18,7 @@ func NewConfig() *Config {
 		Query:       "stars:>1000",
 		DownloadDir: "/tmp/pinned",
 		ResultFile:  "result.json",
+		ResultDir:   "results",
 	}
 }
 

--- a/export.go
+++ b/export.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// runExport implements the "export" subcommand. It reads pinned.json from the
+// result directory and writes it to a specified output file in the format
+// expected by the frontend.
+//
+// Usage:
+//
+//	pinned-actions export --result-dir=results/ --out=web.json
+func runExport(args []string) {
+	fs := flag.NewFlagSet("export", flag.ExitOnError)
+	resultDir := fs.String("result-dir", "results", "directory containing analysis results")
+	out := fs.String("out", "web.json", "output file for the frontend")
+
+	if err := fs.Parse(args); err != nil {
+		fs.PrintDefaults()
+		os.Exit(1)
+	}
+
+	in := filepath.Join(*resultDir, "pinned.json")
+	data, err := os.ReadFile(in)
+	if err != nil {
+		log.Fatalf("reading %s: %v", in, err)
+	}
+
+	// Validate: ensure the file is a JSON array of Analysis objects.
+	var results []Analysis
+	if err := json.Unmarshal(data, &results); err != nil {
+		log.Fatalf("parsing %s: %v", in, err)
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		log.Fatalf("creating %s: %v", *out, err)
+	}
+	defer f.Close()
+
+	if err := json.NewEncoder(f).Encode(results); err != nil {
+		log.Fatalf("writing %s: %v", *out, err)
+	}
+
+	fmt.Printf("Exported %d repositories to %s\n", len(results), *out)
+}

--- a/export.go
+++ b/export.go
@@ -42,10 +42,12 @@ func runExport(args []string) {
 	if err != nil {
 		log.Fatalf("creating %s: %v", *out, err)
 	}
-	defer f.Close()
-
 	if err := json.NewEncoder(f).Encode(results); err != nil {
+		_ = f.Close()
 		log.Fatalf("writing %s: %v", *out, err)
+	}
+	if err := f.Close(); err != nil {
+		log.Fatalf("closing %s: %v", *out, err)
 	}
 
 	fmt.Printf("Exported %d repositories to %s\n", len(results), *out)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 			select {
 
 			case repo := <-downloaded:
-				analysis, err := AnalyseRepository(config.DownloadDir, repo)
+				analysis, err := analyseRepository(config.DownloadDir, repo)
 				if err != nil {
 					log.Printf("[ERROR] analysing repository: %v", err)
 					continue

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"os"
-	"sync"
 
 	"github.com/google/go-github/v85/github"
 )
@@ -22,55 +20,32 @@ func main() {
 
 	ctx := context.Background()
 
-	done := make(chan bool)
+	analyzers := []Analyzer{
+		NewPinnedAnalyzer(config.ResultDir),
+	}
+
 	downloaded := make(chan string)
 	downloader := NewRepositoryDownloader(client, config)
 
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
 	go func() {
-		defer wg.Done()
-
-		var analyzed []Analysis
-
-		for {
-			select {
-
-			case repo := <-downloaded:
-				analysis, err := analyseRepository(config.DownloadDir, repo)
-				if err != nil {
-					log.Printf("[ERROR] analysing repository: %v", err)
-					continue
-				}
-				analyzed = append(analyzed, analysis)
-
-			case <-done:
-				resultFile, err := os.Create(config.ResultFile)
-				if err != nil {
-					log.Fatalf("creating output file: %v", err)
-				}
-
-				err = json.NewEncoder(resultFile).Encode(analyzed)
-				if err != nil {
-					log.Fatalf("encoding output file: %v", err)
-				}
-
-				return
-			}
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-
 		err := downloader.Download(ctx, downloaded)
 		if err != nil {
 			log.Fatalf("downloading: %v", err)
 		}
-
-		done <- true
+		close(downloaded)
 	}()
 
-	wg.Wait()
+	for repo := range downloaded {
+		for _, a := range analyzers {
+			if err := a.Analyze(ctx, config.DownloadDir, repo); err != nil {
+				log.Printf("[ERROR] %s: analysing %s: %v", a.Name(), repo, err)
+			}
+		}
+	}
+
+	for _, a := range analyzers {
+		if err := a.Close(); err != nil {
+			log.Fatalf("closing analyzer %s: %v", a.Name(), err)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -62,8 +62,14 @@ func buildAnalyzers(config Config, client *github.Client) ([]Analyzer, error) {
 		switch name {
 		case "pinned":
 			analyzers = append(analyzers, NewPinnedAnalyzer(config.ResultDir))
+		case "zizmor":
+			a, err := NewZizmorAnalyzer(config.ResultDir)
+			if err != nil {
+				return nil, err
+			}
+			analyzers = append(analyzers, a)
 		default:
-			return nil, fmt.Errorf("unknown analyzer %q (available: pinned)", name)
+			return nil, fmt.Errorf("unknown analyzer %q (available: pinned, zizmor)", name)
 		}
 	}
 	return analyzers, nil

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -24,8 +25,9 @@ func main() {
 		log.Fatalf("creating result directory: %v", err)
 	}
 
-	analyzers := []Analyzer{
-		NewPinnedAnalyzer(config.ResultDir),
+	analyzers, err := buildAnalyzers(config, client)
+	if err != nil {
+		log.Fatalf("configuring analyzers: %v", err)
 	}
 
 	downloaded := make(chan string)
@@ -52,4 +54,17 @@ func main() {
 			log.Fatalf("closing analyzer %s: %v", a.Name(), err)
 		}
 	}
+}
+
+func buildAnalyzers(config Config, client *github.Client) ([]Analyzer, error) {
+	var analyzers []Analyzer
+	for _, name := range config.Analyzers {
+		switch name {
+		case "pinned":
+			analyzers = append(analyzers, NewPinnedAnalyzer(config.ResultDir))
+		default:
+			return nil, fmt.Errorf("unknown analyzer %q (available: pinned)", name)
+		}
+	}
+	return analyzers, nil
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "export" {
+		runExport(os.Args[2:])
+		return
+	}
+
 	config := ParseArgs()
 	log.Printf("Configuration:\n%s", config)
 

--- a/main.go
+++ b/main.go
@@ -68,8 +68,10 @@ func buildAnalyzers(config Config, client *github.Client) ([]Analyzer, error) {
 				return nil, err
 			}
 			analyzers = append(analyzers, a)
+		case "immutable":
+			analyzers = append(analyzers, NewImmutableReleasesAnalyzer(client, config.ResultDir))
 		default:
-			return nil, fmt.Errorf("unknown analyzer %q (available: pinned, zizmor)", name)
+			return nil, fmt.Errorf("unknown analyzer %q (available: pinned, zizmor, immutable)", name)
 		}
 	}
 	return analyzers, nil

--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ func main() {
 
 	ctx := context.Background()
 
+	if err := os.MkdirAll(config.ResultDir, 0o755); err != nil {
+		log.Fatalf("creating result directory: %v", err)
+	}
+
 	analyzers := []Analyzer{
 		NewPinnedAnalyzer(config.ResultDir),
 	}


### PR DESCRIPTION
## Summary

Introduces a pluggable `Analyzer` interface and three concrete implementations, replacing the hardcoded single-pass analysis with an opt-in, extensible pipeline.

- **`Analyzer` interface** — `Name()`, `Analyze(ctx, repoPath, repo)`, `Close()`
- **`PinnedAnalyzer`** — existing pin-by-hash logic, unchanged behavior, writes `results/pinned.json`
- **`ZizmorAnalyzer`** — shells out to `zizmor` (must be on `$PATH`), writes `results/zizmor.json`
- **`ImmutableReleasesAnalyzer`** — calls `GET /repos/{owner}/{repo}/releases/latest`, writes `results/immutable.json`
- **`--analyzer`** flag — opt-in, comma-separated (e.g. `--analyzer=pinned,zizmor`); default is `pinned`
- **`--result-dir`** flag — replaces `--result-file`; each analyzer writes its own file under this directory
- **`export` subcommand** — `pinned-actions export --result-dir=results/ --out=web.json` translates `pinned.json` to the frontend format

## Commit structure

Each commit is independently reviewable and leaves build + tests green:

1. `refactor: extract Analyzer interface`
2. `refactor: wrap existing logic in PinnedAnalyzer`
3. `refactor: update runner to use []Analyzer`
4. `feat: replace --result-file with --result-dir`
5. `feat: add --analyzer opt-in flag`
6. `feat: add ZizmorAnalyzer`
7. `feat: add ImmutableReleasesAnalyzer`
8. `feat: add export subcommand`

## Test plan

- [ ] `go build ./...` and `go test ./...` pass
- [ ] `pinned-actions --analyzer=pinned` produces `results/pinned.json` with existing format
- [ ] `pinned-actions --analyzer=zizmor` (with `zizmor` on `$PATH`) produces `results/zizmor.json`
- [ ] `pinned-actions --analyzer=immutable` (with `GITHUB_TOKEN` set) produces `results/immutable.json`
- [ ] `pinned-actions --analyzer=unknown` exits with a clear error message
- [ ] `pinned-actions export --result-dir=results/ --out=web.json` round-trips `pinned.json` correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)