### PR TITLE
fix: block on GitHub rate limit in immutable analyzer

### DIFF
--- a/analysis_immutable.go
+++ b/analysis_immutable.go
@@ -36,6 +36,8 @@ func NewImmutableReleasesAnalyzer(client *github.Client, resultDir string) *Immu
 func (im *ImmutableReleasesAnalyzer) Name() string { return "immutable" }
 
 func (im *ImmutableReleasesAnalyzer) Analyze(ctx context.Context, _, repo string) error {
+	ctx = context.WithValue(ctx, github.SleepUntilPrimaryRateLimitResetWhenRateLimited, true)
+
 	parts := strings.SplitN(repo, "/", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("unexpected repo format %q (want owner/name)", repo)


### PR DESCRIPTION
## Summary

- Adds `github.SleepUntilPrimaryRateLimitResetWhenRateLimited` to the context in `ImmutableReleasesAnalyzer.Analyze`, matching the same pattern already used in `RepositoryDownloader.Download`
- When the GitHub API returns a rate limit response, the go-github client now sleeps until the reset window instead of returning an error that causes the repository to be skipped
- 404 (no releases published) path is unaffected

## Test plan

- [ ] Run the immutable analyzer against 10k repos with a token that hits rate limits — verify it blocks and resumes rather than logging errors and skipping repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)